### PR TITLE
Potential fix for code scanning alert no. 8: Information exposure through an exception

### DIFF
--- a/rag_app/views.py
+++ b/rag_app/views.py
@@ -398,8 +398,11 @@ def clear_conversation(request):
         return Response({'message': 'Conversation cleared successfully'})
 
     except Exception as e:
+        import logging
+        logger = logging.getLogger(__name__)
+        logger.error("Failed to clear conversation", exc_info=True)
         return Response({
-            'error': f'Failed to clear conversation: {str(e)}'
+            'error': 'An internal server error occurred.'
         }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/doc-reader/security/code-scanning/8](https://github.com/djleamen/doc-reader/security/code-scanning/8)

To fix the issue, we will:
1. Replace the exposed `str(e)` in the response with a generic error message that does not reveal internal details.
2. Log the detailed exception information (e.g., stack trace) server-side to ensure developers can debug effectively while keeping sensitive information hidden from clients.

Specifically, we will:
- Use Django's `logger` module to log the exception details.
- Replace the error response with a generic message like "An internal server error occurred."

The changes will be applied to the `clear_conversation` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
