### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through an exception

### DIFF
--- a/rag_app/views.py
+++ b/rag_app/views.py
@@ -374,8 +374,11 @@ def index_stats(request):
         return Response(stats)
 
     except Exception as e:
+        import logging
+        logger = logging.getLogger(__name__)
+        logger.error("Failed to get stats", exc_info=True)
         return Response({
-            'error': f'Failed to get stats: {str(e)}'
+            'error': 'An internal server error occurred while retrieving stats.'
         }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/doc-reader/security/code-scanning/7](https://github.com/djleamen/doc-reader/security/code-scanning/7)

To fix this issue, we need to ensure that exception details are not directly exposed to users in the HTTP response. Instead:
1. Log the detailed exception message and stack trace on the server side using proper logging mechanisms.
2. Return a generic error message to the client that does not reveal sensitive information.

The changes should:
- Replace the current code that includes `str(e)` in the response with a generic error message.
- Introduce server-side logging using a Python logging module or a similar mechanism if not already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
