### PR TITLE
Potential fix for code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/rag_app/views.py
+++ b/rag_app/views.py
@@ -322,13 +322,19 @@ class ConversationalQueryView(APIView):
                 })
 
             except Exception as e:
+                import logging
+                logger = logging.getLogger(__name__)
+                logger.error("Conversational query failed", exc_info=True)
                 return Response({
-                    'error': f'Conversational query failed: {str(e)}'
+                    'error': 'An internal server error occurred during the conversational query.'
                 }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         except Exception as e:
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.error("Request processing failed", exc_info=True)
             return Response({
-                'error': f'Request failed: {str(e)}'
+                'error': 'An internal server error occurred while processing the request.'
             }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/doc-reader/security/code-scanning/6](https://github.com/djleamen/doc-reader/security/code-scanning/6)

To fix the issue, we need to suppress the exposure of sensitive information in exception messages returned to the user. Instead, we should log the exception details securely on the server and return a generic error message to the user. This ensures that developers can still debug issues using server logs while protecting sensitive application details from external exposure.

#### Steps:
1. Replace the raw exception message (`str(e)`) in the `Response` object with a generic error message such as `"An internal server error has occurred."`.
2. Log the exception details securely using Python's `logging` module for further analysis by developers.
3. The changes apply to both the outer `except` block starting at line 329 and the inner `except` block starting at line 324.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
