### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,5 +1,8 @@
 name: Django CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/doc-reader/security/code-scanning/14](https://github.com/djleamen/doc-reader/security/code-scanning/14)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the steps in the workflow, it appears that the workflow only needs read access to the repository contents. Therefore, we will set `contents: read` in the `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
