### PR TITLE
Potential fix for code scanning alert no. 15: Information exposure through an exception

### DIFF
--- a/rag_app/views.py
+++ b/rag_app/views.py
@@ -457,7 +457,7 @@ def clear_documents(request):
     except (OSError, IOError, ValueError, RuntimeError) as e:
         logger_instance.error("Failed to clear documents", exc_info=True)
         return Response({
-            'error': f'Failed to clear documents: {str(e)}'
+            'error': 'Failed to clear documents due to a server error.'
         }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/doc-reader/security/code-scanning/15](https://github.com/djleamen/doc-reader/security/code-scanning/15)

To fix the issue, we should return only a generic error message to the user, and log the full exception (including stack trace information) using the server-side logger. 

Specifically, in `rag_app/views.py` line 459:
- Replace the response which returns `'error': f'Failed to clear documents: {str(e)}'` with a generic message, e.g. `'error': 'Failed to clear documents due to a server error.'`.
- Ensure the detailed error, including stack trace, is logged using the logger (which is already handled with `exc_info=True`).

No new imports or custom error-handling functions are needed, as logging is already set up.

Only the block handling the exception in `clear_documents` needs alteration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
