### PR TITLE
Potential fix for code scanning alert no. 23: Information exposure through an exception

### DIFF
--- a/rag_app/azure_views.py
+++ b/rag_app/azure_views.py
@@ -429,9 +429,9 @@ def azure_health_check(request):
         }, status=http_status)
 
     except Exception as e:
-        logger.error(f"Azure health check failed: {e}")
+        logger.exception("Azure health check failed")  # log full stack trace
         return JsonResponse({
             'status': 'unhealthy',
-            'error': str(e),
+            'error': 'An internal error occurred.',
             'pipeline': 'azure',
         }, status=503)


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/doc-reader/security/code-scanning/23](https://github.com/djleamen/doc-reader/security/code-scanning/23)

The safest way to fix the problem is to avoid returning the exception message directly to the client.  
Instead, return a generic error message such as "An internal error occurred" while logging the full exception (including stack trace) for the server's benefit. This can be achieved by:
- Changing the JSON response on line 433 to remove `error: str(e)` and replace it with a fixed message, e.g. `"error": "An internal error occurred."`
- Optionally, keep logging the error internally using the logger, potentially with full stack trace (e.g. `logger.exception(...)` if supported).
Only the code in rag_app/azure_views.py needs to be changed, specifically the block under `azure_health_check` for the exception handler.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
