### PR TITLE
Potential fix for code scanning alert no. 22: Information exposure through an exception

### DIFF
--- a/rag_app/azure_views.py
+++ b/rag_app/azure_views.py
@@ -384,7 +384,7 @@ def azure_clear_conversation(request):
     except Exception as e:
         logger.error(f"Failed to clear Azure conversation: {e}")
         return JsonResponse(
-            {'error': str(e)},
+            {'error': 'An internal error occurred.'},
             status=500
         )
 


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/doc-reader/security/code-scanning/22](https://github.com/djleamen/doc-reader/security/code-scanning/22)

To fix the problem, we should no longer return the actual error message (`str(e)`) directly to the API user in the response. Instead, return a generic error message such as `"An internal error occurred."`, while still logging the details (including stack trace if desired) on the server for debugging purposes. The fix should occur inside the exception handler block of `azure_clear_conversation` within rag_app/azure_views.py, specifically lines 384-389. No new methods or packages are required, as logging is already handled via `logger.error`. Ensure the API output to the user contains only generic error information and does not expose internal exception details.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
