### PR TITLE
Potential fix for code scanning alert no. 21: Information exposure through an exception

### DIFF
--- a/rag_app/azure_views.py
+++ b/rag_app/azure_views.py
@@ -343,7 +343,7 @@ def azure_clear_cache(request):
     except Exception as e:
         logger.error(f"Failed to clear Azure cache: {e}")
         return JsonResponse(
-            {'error': str(e)},
+            {'error': 'An internal error occurred.'},
             status=500
         )
 


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/doc-reader/security/code-scanning/21](https://github.com/djleamen/doc-reader/security/code-scanning/21)

The appropriate way to fix this issue is to avoid returning the raw exception message to the end user. Instead, log the detailed exception for developers/operations (which is already done via `logger.error`), and return a generic error message to the client. This means replacing `{'error': str(e)}` with a more generic response such as `{'error': 'An internal error occurred.'}`.

**Steps to fix:**
- In rag_app/azure_views.py, within the azure_clear_cache view (lines 343–348), change the error response in the `except` block from using `str(e)` to a generic error message, consistent with the approach in `azure_clear_conversation`.
- No new imports are required, as logging is already set up.
- No changes are required to any other part of the file beyond this `except` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
