### PR TITLE
Potential fix for code scanning alert no. 20: Information exposure through an exception

### DIFF
--- a/rag_app/azure_views.py
+++ b/rag_app/azure_views.py
@@ -308,7 +308,7 @@ def azure_index_stats(request):
     except Exception as e:
         logger.error(f"Failed to get Azure stats: {e}")
         return JsonResponse(
-            {'error': str(e)},
+            {'error': 'An internal error occurred.'},
             status=500
         )
 


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/doc-reader/security/code-scanning/20](https://github.com/djleamen/doc-reader/security/code-scanning/20)

To address the information exposure, we should stop returning the raw exception message (`str(e)`) in API responses. Instead, return a generic error message like `'An internal error occurred.'` to the user, while retaining the logging of the actual exception message server-side for debugging and auditing. The fix involves modifying the error handler in the `azure_index_stats` function (lines 308-313):  
- Change the user-facing error response so it no longer includes `str(e)`; replace it with a generic message as in similar code for `azure_clear_cache`.
- Leave the server-side logging unchanged, so developers still receive details about the failure.
No additional imports or external dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
