### PR TITLE
Potential fix for code scanning alert no. 19: Information exposure through an exception

### DIFF
--- a/rag_app/azure_views.py
+++ b/rag_app/azure_views.py
@@ -274,7 +274,7 @@ class AzureConversationalQueryView(APIView):
         except Exception as e:
             logger.error(f"Azure conversational query failed: {e}")
             return Response(
-                {'error': str(e)},
+                {'error': 'An internal error occurred.'},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
 


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/doc-reader/security/code-scanning/19](https://github.com/djleamen/doc-reader/security/code-scanning/19)

The best fix is to avoid passing the exception details (from `str(e)`) directly to the API response. Instead, a generic message such as "An internal error occurred." should be sent to the client. The actual details (str(e)) should be kept in the logs for troubleshooting, which is mostly already done via the existing `logger.error()` call. 

The changes need to be made only in the `except` block inside the `post()` method of the `AzureConversationalQueryView` class. Specifically, replace `{'error': str(e)}` with a generic message such as `{'error': 'An internal error occurred.'}`. No new imports are needed since logging is already performed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
