### PR TITLE
Potential fix for code scanning alert no. 18: Information exposure through an exception

### DIFF
--- a/rag_app/azure_views.py
+++ b/rag_app/azure_views.py
@@ -184,7 +184,7 @@ class AzureQueryView(APIView):
         except Exception as e:
             logger.error(f"Azure query failed: {e}")
             return Response(
-                {'error': str(e)},
+                {'error': 'An internal error has occurred.'},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
 


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/doc-reader/security/code-scanning/18](https://github.com/djleamen/doc-reader/security/code-scanning/18)

To fix this, only a generic error message should be exposed to the end user; the specific error message in `e` should not be included in the API response. Instead, keep the exception and stack trace logged server-side for debugging. The fix is to change line 187 from `{'error': str(e)}` to a generic message like `{'error': 'An internal error has occurred.'}`.

No additional imports are needed since logging is already used. The change is limited to the `except` block within the `post` method of `AzureQueryView` in `rag_app/azure_views.py`. No other change is required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
