### PR TITLE
Potential fix for code scanning alert no. 17: Information exposure through an exception

### DIFF
--- a/rag_app/azure_views.py
+++ b/rag_app/azure_views.py
@@ -102,7 +102,7 @@ class AzureDocumentUploadView(APIView):
         except Exception as e:
             logger.error(f"Document upload failed: {e}")
             return Response(
-                {'error': str(e)},
+                {'error': 'An internal error has occurred.'},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
 


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/doc-reader/security/code-scanning/17](https://github.com/djleamen/doc-reader/security/code-scanning/17)

To fix this issue, we need to ensure that detailed exception messages are never sent to the end user. Instead, we should:
- Log the exception message and stack trace for administrator debugging (as is currently being done using `logger.error`).
- Return a generic and non-informative error message to the user (for example: `"An internal error has occurred."`).

We only need to change the problematic response in the global exception handler in the `post` method of `AzureDocumentUploadView` (around lines 104-106):
- Replace: `{'error': str(e)}`
- With: `{'error': 'An internal error has occurred.'}`

No new imports are needed, as logging is already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
