### PR TITLE
Potential fix for code scanning alert no. 16: Information exposure through an exception

### DIFF
--- a/rag_app/azure_views.py
+++ b/rag_app/azure_views.py
@@ -89,7 +89,7 @@ class AzureDocumentUploadView(APIView):
                     results.append({
                         'status': 'error',
                         'file': file.name,
-                        'error': str(e)
+                        'error': 'An internal error occurred while processing this file.'
                     })
 
             return Response({

--- a/src/az_rag_engine.py
+++ b/src/az_rag_engine.py
@@ -142,7 +142,7 @@ class AzureRAGEngine:
             logger.error(f"Failed to add document: {e}")
             return {
                 "status": "error",
-                "error": str(e),
+                "error": "An internal error occurred while processing this file.",
                 "file_path": file_path,
             }
 


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/doc-reader/security/code-scanning/16](https://github.com/djleamen/doc-reader/security/code-scanning/16)

To fix this problem, the code must prevent internal exception details from being returned to the API user in the `"error"` field of results. Specifically:

- Instead of passing `str(e)` or any part of the exception back to the client, log the detailed error (including the exception message) server-side and generate a generic error message for the client.
- In `src/az_rag_engine.py`, update the `add_document` method so that its returned error result uses a generic string, e.g., `"An internal error occurred while processing this file."`, instead of including any details from `e` in the returned dict.
- In `rag_app/azure_views.py`, when catching exceptions in the per-file try/except, do not add `str(e)` to the `results` list returned to the client, but log the error fully for operators/developers.

All other functionality should remain unchanged: failures are accumulated for per-file processing and the API returns success or error summaries for all requested files.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
