### PR TITLE
fix(api): validate file extensions on upload and stop leaking raw errors

### DIFF
--- a/rag_app/tests.py
+++ b/rag_app/tests.py
@@ -266,6 +266,29 @@ class APIViewsTest(TestCase):
         # The test verifies the endpoint exists and handles the request
         self.assertIn(response.status_code, [200, 500])  # 500 if dependencies missing
 
+    def test_upload_unsupported_file_type(self):
+        '''
+        Test document upload with an unsupported file type.
+
+        Verifies unsupported extensions are rejected with a per-file
+        error before any Document records are created.
+        '''
+        test_file = SimpleUploadedFile(
+            "malware.exe",
+            b"MZ fake executable content",
+            content_type="application/octet-stream"
+        )
+        response = self.client.post('/api/upload-documents/', {
+            'files': [test_file],
+            'index_name': 'test_index'
+        })
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['files_processed'], [])
+        self.assertEqual(len(data['errors']), 1)
+        self.assertIn('Unsupported file type', data['errors'][0])
+        self.assertEqual(Document.objects.count(), 0)
+
 
 class WebViewsTest(TestCase):
     '''

--- a/rag_app/views.py
+++ b/rag_app/views.py
@@ -139,12 +139,22 @@ class DocumentUploadView(APIView):
 
             rag_engine = get_rag_engine(index_name)
 
+            supported_formats = rag_settings.supported_formats_list
+
             for file in files:
                 try:
                     # Validate file
                     max_file_size = rag_settings.max_document_size_mb * 1024 * 1024
                     if file.size > max_file_size:
                         errors.append(f"{file.name}: File too large")
+                        continue
+
+                    file_type = file.name.rsplit('.', 1)[-1].lower() if '.' in file.name else ''
+                    if file_type not in supported_formats:
+                        errors.append(
+                            f"{file.name}: Unsupported file type "
+                            f"(supported: {', '.join(supported_formats)})"
+                        )
                         continue
 
                     # Save file temporarily
@@ -161,7 +171,7 @@ class DocumentUploadView(APIView):
                         original_filename=file.name,
                         file_path=file_path,
                         file_size=file.size,
-                        file_type=file.name.split('.')[-1].lower(),
+                        file_type=file_type,
                         chunk_count=0
                     )
 
@@ -176,9 +186,12 @@ class DocumentUploadView(APIView):
                         total_chunks += (chunks_added or 0)
 
                     except (OSError, IOError, ValueError, RuntimeError) as e:
+                        logger.error("Failed to process file %s: %s", file.name, e)
                         document.processing_error = str(e)
                         document.save()
-                        errors.append(f"{file.name}: {str(e)}")
+                        errors.append(
+                            f"{file.name}: An internal error occurred while processing this file."
+                        )
 
                     finally:
                         # Clean up temp file
@@ -186,7 +199,10 @@ class DocumentUploadView(APIView):
                             default_storage.delete(temp_path)
 
                 except (OSError, IOError, ValueError, RuntimeError) as e:
-                    errors.append(f"{file.name}: {str(e)}")
+                    logger.error("Failed to upload file %s: %s", file.name, e)
+                    errors.append(
+                        f"{file.name}: An internal error occurred while processing this file."
+                    )
 
             _refresh_index_counts(index)
 
@@ -198,8 +214,9 @@ class DocumentUploadView(APIView):
             })
 
         except (OSError, IOError, ValueError, RuntimeError) as e:
+            logger.error("Upload failed: %s", e, exc_info=True)
             return Response({
-                'error': f'Upload failed: {str(e)}'
+                'error': 'Upload failed due to an internal error'
             }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 

--- a/rag_app/views.py
+++ b/rag_app/views.py
@@ -28,6 +28,8 @@ _rag_engines = {}
 _conversational_rags = {}
 logger = logging.getLogger(__name__)
 
+FILE_PROCESSING_ERROR_MESSAGE = 'An internal error occurred while processing this file.'
+
 
 def _parse_request_data(request):
     """Read JSON or form-encoded payloads into a plain dictionary."""
@@ -189,9 +191,7 @@ class DocumentUploadView(APIView):
                         logger.error("Failed to process file %s: %s", file.name, e)
                         document.processing_error = str(e)
                         document.save()
-                        errors.append(
-                            f"{file.name}: An internal error occurred while processing this file."
-                        )
+                        errors.append(f"{file.name}: {FILE_PROCESSING_ERROR_MESSAGE}")
 
                     finally:
                         # Clean up temp file
@@ -200,9 +200,7 @@ class DocumentUploadView(APIView):
 
                 except (OSError, IOError, ValueError, RuntimeError) as e:
                     logger.error("Failed to upload file %s: %s", file.name, e)
-                    errors.append(
-                        f"{file.name}: An internal error occurred while processing this file."
-                    )
+                    errors.append(f"{file.name}: {FILE_PROCESSING_ERROR_MESSAGE}")
 
             _refresh_index_counts(index)
 

--- a/rag_app/views.py
+++ b/rag_app/views.py
@@ -188,7 +188,7 @@ class DocumentUploadView(APIView):
                         total_chunks += (chunks_added or 0)
 
                     except (OSError, IOError, ValueError, RuntimeError) as e:
-                        logger.error("Failed to process file %s: %s", file.name, e)
+                        logger.error("Failed to process file %s: %s", file.name, e, exc_info=True)
                         document.processing_error = str(e)
                         document.save()
                         errors.append(f"{file.name}: {FILE_PROCESSING_ERROR_MESSAGE}")
@@ -199,7 +199,7 @@ class DocumentUploadView(APIView):
                             default_storage.delete(temp_path)
 
                 except (OSError, IOError, ValueError, RuntimeError) as e:
-                    logger.error("Failed to upload file %s: %s", file.name, e)
+                    logger.error("Failed to upload file %s: %s", file.name, e, exc_info=True)
                     errors.append(f"{file.name}: {FILE_PROCESSING_ERROR_MESSAGE}")
 
             _refresh_index_counts(index)

--- a/src/config.py
+++ b/src/config.py
@@ -77,9 +77,14 @@ class Settings:
         '''
         Get supported formats as a list.
         
-        :return: List of supported file format extensions
+        :return: List of supported file format extensions, normalized to
+                 lowercase without leading dots, with empty entries removed
         '''
-        return [fmt.strip() for fmt in self.supported_formats.split(',')]
+        return [
+            fmt.strip().lstrip('.').lower()
+            for fmt in self.supported_formats.split(',')
+            if fmt.strip().lstrip('.')
+        ]
 
 
 # Global settings instance


### PR DESCRIPTION
## Problem
Two weaknesses in `DocumentUploadView` (`rag_app/views.py`):

1. **No file-type validation** — any extension was accepted: a temp file was written, a `Document` row was created, and only then would the RAG engine fail on unsupported formats, leaving failed `Document` records behind for files that could never be processed.
2. **Raw exception text returned to clients** — `str(e)` was echoed in the `errors` array and the top-level `Upload failed: ...` response, which can leak filesystem paths and internal details. The Azure views (`azure_views.py`) already use a generic message; the standard view didn't.

## Fix
- Validate each file's extension against `SUPPORTED_FORMATS` (`rag_settings.supported_formats_list`) before any storage or DB writes, mirroring the existing check in `src/document_processor.py`. Unsupported files get a clear per-file error listing the supported formats.
- Client-facing per-file and top-level errors now use the same generic wording as the Azure views; full exception details still go to the server log and the `processing_error` model field.

This is intentionally scoped — the broader auth hardening remains tracked in #71.

## Testing
- `python3 manage.py test rag_app.tests` — all 11 tests pass.
- Manual check via Django test client: uploading `evil.exe` returns 200 with `evil.exe: Unsupported file type (supported: pdf, docx, txt, md)` and creates **zero** `Document` records.

https://claude.ai/code/session_01HpkgffKPn2ZtJDRNGzFm83

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpkgffKPn2ZtJDRNGzFm83)_