### PR TITLE
Create RAG engine lazily in upload view; ignore .venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ wheels/
 
 # Virtual environments
 venv/
+.venv/
 env/
 ENV/
 

--- a/rag_app/views.py
+++ b/rag_app/views.py
@@ -139,7 +139,9 @@ class DocumentUploadView(APIView):
             errors = []
             total_chunks = 0
 
-            rag_engine = get_rag_engine(index_name)
+            # Created lazily so validation-only failures (e.g. unsupported
+            # file types) do not require the RAG engine dependencies.
+            rag_engine = None
 
             supported_formats = rag_settings.supported_formats_list
 
@@ -179,6 +181,8 @@ class DocumentUploadView(APIView):
 
                     try:
                         # Process document
+                        if rag_engine is None:
+                            rag_engine = get_rag_engine(index_name)
                         chunks_added = rag_engine.add_documents([file_path])
                         document.chunk_count = chunks_added or 0
                         document.processed = True


### PR DESCRIPTION
## Testing summary

- Reused the repo-local `.venv` (all requirements already installed) and added it to `.gitignore` (only `venv/` was listed, so `.venv/` showed up as untracked).
- `py_compile` passes for `manage.py`, `main.py`, `setup.py`, and everything under `src/`, `django_app/`, and `rag_app/` (including migrations).
- `manage.py check`: no issues.
- `manage.py migrate` on a scratch sqlite DB: all migrations apply cleanly, including the `rag_app` merge migration chain.
- `manage.py test rag_app`: 12/12 tests pass after the fix below (11/12 before).
- Ran the dev server and curled endpoints:
  - `GET /api/health/` → healthy; `GET /` → 200; unknown route → 404.
  - Edge cases: empty question → 400; unknown index → 404; malformed JSON → 400 with a clean message; upload with no files → 400; `POST` to the DELETE-only conversation endpoint → 405; `DELETE /api/conversation/` with no session → 200.
  - Upload of an unsupported `.exe` → 200 with a per-file "Unsupported file type" error and no Document rows created.
  - Upload of a valid `.txt` without model access → 200 with a per-file processing error (graceful degradation).
- Not testable here: the OpenAI-backed query path and the entire Azure pipeline (`/api/azure/*` health correctly reports 503 unhealthy without credentials), plus embedding model downloads (no Hugging Face access from this environment).

## Fixes

- `DocumentUploadView` constructed the RAG engine before any per-file validation ran, so requests that should fail validation (e.g. unsupported file types) returned 500 whenever engine dependencies were unavailable. The engine is now created lazily, only once a file passes validation — matching the documented intent of `test_upload_unsupported_file_type`, which previously failed.
- Added `.venv/` to `.gitignore`.

https://claude.ai/code/session_01Pdr2u5eE9XswikXHCjZNs5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pdr2u5eE9XswikXHCjZNs5)_