### PR TITLE
chore(deps): bump pypdf to 6.12.0 for PDF-parsing security fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ azure-storage-blob>=12.19.0
 azure-keyvault-secrets>=4.7.0
 
 # Document processing
-pypdf==6.10.2
+pypdf==6.12.0
 python-docx==1.1.0
 python-pptx==0.6.23
 python-magic==0.4.27


### PR DESCRIPTION
## What

Bumps `pypdf` from `6.10.2` to `6.12.0` in `requirements.txt`.

## Why

pypdf 6.12.0 ships two security (SEC) fixes that are directly relevant to doc-reader, which parses **user-supplied PDFs**:

- Disallows cross-reference streams with zero-only width values (malformed/malicious PDF hardening)
- Avoids excessive whitespace in layout-mode text extraction (resource-exhaustion hardening)

## Why a separate PR instead of just merging Dependabot #76

Dependabot grouped this pypdf bump together with `langchain-openai 0.3.35 → 1.1.14` in #76. That `langchain-openai` jump is a **major** version bump that is explicitly blocked by the langchain 1.x migration tracked in #73 — merging #76 as-is would break the app. This PR decouples the safe, security-relevant pypdf patch so it can land now, independent of the larger langchain migration.

Once #73 is done, the langchain portion of #76 can be handled on its own.

## Testing

Dependency-only change (single pinned version). CI test suite (`pytest`) covers PDF ingestion; no source changes.

Refs #73, #76

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQrELdvvz3uNXU6ysASTP5)_