### PR TITLE
Make REST API permission policy configurable (REQUIRE_API_AUTH)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,3 +78,7 @@ SUPPORTED_FORMATS=pdf,docx,txt,md
 HOST=0.0.0.0
 PORT=8000
 DEBUG=False
+
+# Require an authenticated session for all REST API endpoints.
+# Leave False for local use; set True in production (auth via Django admin login).
+REQUIRE_API_AUTH=False

--- a/django_app/settings.py
+++ b/django_app/settings.py
@@ -123,10 +123,14 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 20,
-    # Security: Require authentication for all views by default
-    # Individual views can override this with @api_view decorators or permission_classes
+    # Permission policy. Defaults to AllowAny so local/dev usage works without a
+    # login flow. Set REQUIRE_API_AUTH=True to require an authenticated session
+    # (e.g. via Django admin login) for every endpoint in production.
+    # Individual views can still override this with permission_classes.
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.AllowAny',  # For development
+        'rest_framework.permissions.IsAuthenticated'
+        if os.getenv('REQUIRE_API_AUTH', 'False').lower() == 'true'
+        else 'rest_framework.permissions.AllowAny',
     ],
     # Enable CSRF protection for session authentication
     'DEFAULT_AUTHENTICATION_CLASSES': [


### PR DESCRIPTION
Addresses #78.

The DRF default was `AllowAny` while the adjacent comment claimed authentication was required for all views. There is no login flow in the app, so unconditionally switching to `IsAuthenticated` would lock everything out.

This change gates the default permission on a new `REQUIRE_API_AUTH` env var:
- **Default `False`** → `AllowAny` (current behavior, nothing breaks).
- **`True`** → `IsAuthenticated`, so every endpoint requires an authenticated session (via Django admin login). Per-view `permission_classes` still override.

Also fixes the misleading comment and documents the flag in `.env.example`.

> Note: full production lockdown still benefits from a dedicated login UI rather than relying on admin sessions — left as the broader item in #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)