### PR TITLE
fix(security): enforce CSRF on state-changing API endpoints

### DIFF
--- a/rag_app/azure_views.py
+++ b/rag_app/azure_views.py
@@ -11,8 +11,6 @@ from typing import Any, Dict, cast
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.http import JsonResponse
-from django.utils.decorators import method_decorator
-from django.views.decorators.csrf import csrf_exempt
 from loguru import logger
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
@@ -65,7 +63,6 @@ def _build_azure_metadata(result, retrieval_count: int) -> dict[str, Any]:
         **extra_metadata,
     }
 
-@method_decorator(csrf_exempt, name='dispatch')
 class AzureDocumentUploadView(APIView):
     """
     API endpoint for uploading documents to Azure RAG pipeline.
@@ -150,7 +147,6 @@ class AzureDocumentUploadView(APIView):
             )
 
 
-@method_decorator(csrf_exempt, name='dispatch')
 class AzureQueryView(APIView):
     """
     API endpoint for querying Azure RAG pipeline.
@@ -217,7 +213,6 @@ class AzureQueryView(APIView):
             )
 
 
-@method_decorator(csrf_exempt, name='dispatch')
 class AzureConversationalQueryView(APIView):
     """
     API endpoint for conversational queries with Azure RAG pipeline.

--- a/rag_app/views.py
+++ b/rag_app/views.py
@@ -10,8 +10,7 @@ import logging
 
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
-from django.utils.decorators import method_decorator
-from django.views.decorators.csrf import csrf_exempt, csrf_protect
+from django.views.decorators.csrf import csrf_protect
 from django.views.generic import TemplateView
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
@@ -106,7 +105,6 @@ class HomeView(IndexView):
     # Inherits all functionality from IndexView
 
 
-@method_decorator(csrf_exempt, name='dispatch')
 class DocumentUploadView(APIView):
     '''
     Handle document uploads via API.
@@ -223,7 +221,6 @@ class DocumentUploadView(APIView):
             }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
-@method_decorator(csrf_exempt, name='dispatch')
 class QueryView(APIView):
     '''
     Handle document queries.
@@ -318,7 +315,6 @@ class QueryView(APIView):
             }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
-@method_decorator(csrf_exempt, name='dispatch')
 class ConversationalQueryView(APIView):
     '''
     Handle conversational queries.


### PR DESCRIPTION
## Summary

Removes the `@method_decorator(csrf_exempt)` decorators from the three state-changing class-based views — `DocumentUploadView`, `QueryView`, `ConversationalQueryView` — and their Azure counterparts (`AzureDocumentUploadView`, `AzureQueryView`, `AzureConversationalQueryView`).

This completes the remaining item from #71. The two other concerns in that issue have already been addressed on `main`:
- `DEFAULT_PERMISSION_CLASSES` now defaults to `IsAuthenticated` (commit `3ef22c7`)
- CORS no longer reflects all origins under `DEBUG` (commit `a434a2f`)

With `SessionAuthentication` + `IsAuthenticated` now the default, these endpoints are authenticated via session cookies — exactly the case where CSRF protection matters. The `csrf_exempt` decorators were defeating DRF's built-in `SessionAuthentication` CSRF enforcement, leaving authenticated, cookie-based, state-changing endpoints exposed.

## Why this is safe (no client change needed)

The frontend already sends the CSRF token on every one of these calls, so DRF's enforcement applies transparently:

| View (was `csrf_exempt`) | URL | Frontend call | Token |
|---|---|---|---|
| `DocumentUploadView` | `/api/upload-documents/` | POST (index.html:640) | `csrfmiddlewaretoken` in form data (634) |
| `QueryView` | `/api/query/` | POST (708) | `X-CSRFToken` header (713) |
| `ConversationalQueryView` | `/api/conversational-query/` | POST (708) | `X-CSRFToken` header (713) |

The Azure endpoints are reached by the same AJAX blocks (pipeline switch at index.html:433-438), so they carry the same token.

Also drops the now-unused `method_decorator` / `csrf_exempt` imports. `csrf_protect` is preserved for the existing function-based `clear_*` views.

## Verification

- `python -m py_compile` passes on both files.
- Loaded all six view classes through Django (engine deps stubbed) and confirmed `dispatch.csrf_exempt` is `False` for each, and `csrf_protect` is still imported.
- Full test suite (`pytest`) could not run in this environment — it pulls the heavy RAG stack (langchain, faiss, sentence-transformers, azure SDKs) which isn't installed. The change is purely decorator/import removal and is verified statically + via Django class loading.

Closes #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkeW3MApQ4rr8NsEdF7tmi)_