### PR TITLE
fix(upload): validate Azure uploads, apply request timeouts, sanitize storage paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,8 @@ EMBEDDING_MODEL=text-embedding-ada-002
 CHAT_MODEL=gpt-4-turbo-preview
 MAX_TOKENS=4000
 TEMPERATURE=0.1
+# Network timeout (seconds) for outbound LLM/API calls
+REQUEST_TIMEOUT=30
 
 # Vector database settings
 VECTOR_DB_TYPE=faiss  # Options: faiss, chroma, pinecone

--- a/rag_app/azure_views.py
+++ b/rag_app/azure_views.py
@@ -6,6 +6,7 @@ Azure AI Search for retrieval, and Azure OpenAI for answer generation.
 Written by DJ Leamen (2025-2026)
 """
 
+import os
 from typing import Any, Dict, cast
 
 from django.core.files.base import ContentFile
@@ -25,6 +26,7 @@ from src.az_rag_engine import (
     _azure_rag_engines,
     get_azure_rag_engine,
 )
+from src.config import settings as rag_settings
 
 
 # Constants
@@ -101,11 +103,28 @@ class AzureDocumentUploadView(APIView):
             processed_files = []
             errors = []
             total_chunks_added = 0
+            supported_formats = rag_settings.supported_formats_list
+            max_file_size = rag_settings.max_document_size_mb * 1024 * 1024
             for file in files:
                 try:
-                    # Save file temporarily
+                    # Validate size and type before reading the file into memory
+                    if file.size > max_file_size:
+                        errors.append(f"{file.name}: File too large")
+                        continue
+
+                    file_type = file.name.rsplit('.', 1)[-1].lower() if '.' in file.name else ''
+                    if file_type not in supported_formats:
+                        errors.append(
+                            f"{file.name}: Unsupported file type "
+                            f"(supported: {', '.join(supported_formats)})"
+                        )
+                        continue
+
+                    # Save file temporarily. basename guards the storage path
+                    # against traversal via a crafted upload filename.
+                    safe_name = os.path.basename(file.name)
                     file_path = default_storage.save(
-                        f"temp/azure_{file.name}",
+                        f"temp/azure_{safe_name}",
                         ContentFile(file.read())
                     )
                     full_path = default_storage.path(file_path)

--- a/rag_app/views.py
+++ b/rag_app/views.py
@@ -5,6 +5,7 @@ Written by DJ Leamen (2025-2026)
 """
 
 import json
+import os
 import time
 import logging
 
@@ -160,9 +161,11 @@ class DocumentUploadView(APIView):
                         )
                         continue
 
-                    # Save file temporarily
+                    # Save file temporarily. basename guards the storage path
+                    # against traversal via a crafted upload filename.
+                    safe_name = os.path.basename(file.name)
                     temp_path = default_storage.save(
-                        f"temp/{file.name}",
+                        f"temp/{safe_name}",
                         ContentFile(file.read())
                     )
                     file_path = default_storage.path(temp_path)

--- a/src/az_openai_service.py
+++ b/src/az_openai_service.py
@@ -55,6 +55,7 @@ class AzureOpenAIService:
                     azure_endpoint=self.settings.openai_endpoint,
                     api_version=self.settings.openai_api_version,
                     azure_ad_token=token.token,
+                    timeout=self.settings.timeout,
                 )
             elif self.settings.openai_api_key:
                 # Use API Key (for development/testing)
@@ -63,6 +64,7 @@ class AzureOpenAIService:
                     azure_endpoint=self.settings.openai_endpoint,
                     api_key=self.settings.openai_api_key,
                     api_version=self.settings.openai_api_version,
+                    timeout=self.settings.timeout,
                 )
             else:
                 raise ValueError(

--- a/src/config.py
+++ b/src/config.py
@@ -42,6 +42,8 @@ class Settings:
         self.chat_model = os.getenv("CHAT_MODEL", "gpt-4-turbo-preview")
         self.max_tokens = int(os.getenv("MAX_TOKENS", "4000"))
         self.temperature = float(os.getenv("TEMPERATURE", "0.1"))
+        # Network timeout (seconds) for outbound LLM/API calls.
+        self.request_timeout = int(os.getenv("REQUEST_TIMEOUT", "30"))
 
         # Vector Database
         self.vector_db_type = os.getenv("VECTOR_DB_TYPE", "faiss")

--- a/src/rag_engine.py
+++ b/src/rag_engine.py
@@ -70,7 +70,8 @@ class RAGEngine:
         self.llm = ChatOpenAI(
             model=settings.chat_model,
             temperature=settings.temperature,
-            max_tokens=settings.max_tokens
+            max_tokens=settings.max_tokens,
+            timeout=settings.request_timeout
         )
 
         # Create prompt template


### PR DESCRIPTION
## Summary

Four small robustness/security fixes in the upload and LLM paths, found during a cross-repo review. None are architectural — they bring the Azure path up to the hardening the classic path already has and make configured timeouts actually take effect.

## Changes

**1. Validate Azure uploads before reading them into memory** (`rag_app/azure_views.py`)
`AzureDocumentUploadView.post` looped over uploaded files and called `ContentFile(file.read())` on each with **no size or type check** — the classic `DocumentUploadView` already validates both. This allowed memory exhaustion (DoS) from a large upload and processing of arbitrary file types. Ported the same `max_document_size_mb` size guard and `supported_formats_list` extension guard, `continue`-ing with an error message on failure.

**2. Add a request timeout to `ChatOpenAI`** (`src/rag_engine.py`, `src/config.py`)
The classic LLM client was built with no timeout, so a stalled OpenAI call could hang a request worker indefinitely. Added a configurable `request_timeout` setting (`REQUEST_TIMEOUT`, default 30s) and pass it to the `ChatOpenAI` constructor.

**3. Apply the configured `AZURE_TIMEOUT`** (`src/az_openai_service.py`)
`AZURE_TIMEOUT` was read into `settings.timeout` and documented in `.env.example`, but never passed to the `AzureOpenAI` client — so it silently did nothing. Wired `timeout=self.settings.timeout` into both (managed-identity and API-key) constructors.

**4. Sanitize upload filenames in the storage path** (`rag_app/azure_views.py`, `rag_app/views.py`)
Both views interpolated the client-supplied `file.name` straight into the temp storage path. Django's `Storage.save()` does sanitize, but relying on it implicitly is fragile; wrapped with `os.path.basename(...)` as defense-in-depth against path traversal.

Also documented `REQUEST_TIMEOUT` in `.env.example`.

## Testing

- `python -m py_compile` on all changed modules — clean
- Validation/timeout wiring verified to reference existing settings attributes (`request_timeout`, `timeout`, `supported_formats_list`, `max_document_size_mb`)

This does not touch #73 (langchain 1.x migration), which is architectural and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011yZGKAAeSMwoz2rioR2AG8)_