### PR TITLE
fix(views): validate k bounds and coerce booleans on raw-JSON query path

### DIFF
--- a/rag_app/views.py
+++ b/rag_app/views.py
@@ -39,6 +39,22 @@ def _parse_request_data(request):
     return request.POST.dict()
 
 
+def _coerce_bool(value, default=True):
+    """Interpret JSON booleans plus common string/number spellings.
+
+    The raw-JSON query path bypasses ``QueryRequestSerializer``'s
+    ``BooleanField`` coercion, so a client sending ``"false"`` would otherwise
+    be treated as truthy (non-empty string). Normalise those here instead.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ('true', '1', 'yes', 'on')
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return default
+
+
 def _refresh_index_counts(index):
     """Keep persisted index counters aligned with processed documents."""
     processed_documents = Document.objects.filter(index=index, processed=True)
@@ -244,9 +260,25 @@ class QueryView(APIView):
                 }, status=status.HTTP_400_BAD_REQUEST)
 
             index_name = data.get('index_name', 'default')
+
+            # Validate k before it reaches the retriever. This raw-JSON path
+            # bypasses QueryRequestSerializer, so a string, negative, or huge
+            # value would otherwise pass straight through; mirror the
+            # serializer's 1-20 bound (IntegerField(min_value=1, max_value=20)).
             k = data.get('k', rag_settings.top_k_results)
-            include_sources = data.get('include_sources', True)
-            include_scores = data.get('include_scores', True)
+            try:
+                k = int(k)
+            except (TypeError, ValueError):
+                return Response({
+                    'error': 'k must be an integer'
+                }, status=status.HTTP_400_BAD_REQUEST)
+            if not 1 <= k <= 20:
+                return Response({
+                    'error': 'k must be between 1 and 20'
+                }, status=status.HTTP_400_BAD_REQUEST)
+
+            include_sources = _coerce_bool(data.get('include_sources', True))
+            include_scores = _coerce_bool(data.get('include_scores', True))
 
             # Get index
             try:


### PR DESCRIPTION
## Summary

`QueryView.post` reads `k`, `include_sources`, and `include_scores` directly from the raw JSON body, bypassing `QueryRequestSerializer` (which the Azure query path uses). This left two gaps:

- **`k` was unbounded and untyped.** A string, negative, zero, or very large `k` flowed straight into `rag_engine.query(k=...)` → the retriever, risking memory blow-up or an unhandled `TypeError` (the view's `except` only catches `OSError/IOError/ValueError/RuntimeError`).
- **Booleans weren't coerced.** A client sending `"include_sources": "false"` was treated as truthy (non-empty string), leaking source documents when the caller intended to suppress them.

The fix validates `k` against the same `1–20` range the serializer enforces (`IntegerField(min_value=1, max_value=20)`) and normalises the booleans via a small shared `_coerce_bool` helper. The existing `{ 'error': ... }` response shape and the "question is required" check are preserved, so current view tests keep passing.

## Changes
- `rag_app/views.py`: add `_coerce_bool` helper; validate/bound `k` and coerce `include_sources`/`include_scores` in `QueryView.post`.

## Testing
- Verified `k` validation (defaults, valid string ints, negative/zero/huge, non-numeric, float coercion) and boolean coercion (real bools, `"false"`, `"0"`, ints) in isolation — 14/14 cases pass.
- `python -m py_compile rag_app/views.py` passes.
- Django/langchain aren't installed in this environment and `views.py` imports the RAG engine at module load, so the full `manage.py test` suite couldn't be run here; the added logic mirrors the serializer bounds already covered by the codebase and the change sits after the existing question check, so `test_query_without_question` / `test_query_nonexistent_index` contracts are unaffected.

Found during a cross-repo code-quality review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mZVWx5wd5PdHs6n8UihBE

---
_Generated by [Claude Code](https://claude.ai/code/session_012mZVWx5wd5PdHs6n8UihBE)_