### PR TITLE
fix(azure): coerce boolean query flags and clean up temp file on upload error

### DIFF
--- a/rag_app/azure_views.py
+++ b/rag_app/azure_views.py
@@ -33,6 +33,23 @@ from src.config import settings as rag_settings
 INTERNAL_ERROR_MESSAGE = 'An internal error occurred.'
 
 
+def _coerce_bool(value, default=True):
+    """Interpret JSON booleans plus common string/number spellings.
+
+    ``use_hybrid``/``use_semantic`` are read straight off ``request.data``,
+    bypassing ``QueryRequestSerializer``'s ``BooleanField`` coercion, so a
+    client sending ``"false"`` would otherwise be treated as truthy (non-empty
+    string). Normalise those here instead.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ('true', '1', 'yes', 'on')
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return default
+
+
 def _normalize_azure_sources(result) -> tuple[list[dict[str, Any]], list[float]]:
     """Match the classic API response shape expected by the shared UI."""
     source_documents = []
@@ -129,20 +146,23 @@ class AzureDocumentUploadView(APIView):
                     )
                     full_path = default_storage.path(file_path)
 
-                    # Process document
-                    result = rag_engine.add_document(full_path)
-                    if result.get('status') == 'success':
-                        processed_files.append(file.name)
-                        total_chunks_added += int(
-                            result.get('indexed_count') or result.get('chunks') or 0
-                        )
-                    else:
-                        errors.append(
-                            f"{file.name}: {result.get('error', INTERNAL_ERROR_MESSAGE)}"
-                        )
+                    try:
+                        # Process document
+                        result = rag_engine.add_document(full_path)
+                        if result.get('status') == 'success':
+                            processed_files.append(file.name)
+                            total_chunks_added += int(
+                                result.get('indexed_count') or result.get('chunks') or 0
+                            )
+                        else:
+                            errors.append(
+                                f"{file.name}: {result.get('error', INTERNAL_ERROR_MESSAGE)}"
+                            )
 
-                    # Cleanup
-                    default_storage.delete(file_path)
+                    finally:
+                        # Clean up temp file even if processing raised
+                        if default_storage.exists(file_path):
+                            default_storage.delete(file_path)
 
                 except Exception as e:
                     logger.error(f"Failed to process file {file.name}: {e}")
@@ -199,8 +219,8 @@ class AzureQueryView(APIView):
             index_name = validated_data.get('index_name')
             k = validated_data.get('k', 5)
             include_sources = validated_data.get('include_sources', True)
-            use_hybrid = request.data.get('use_hybrid', True)
-            use_semantic = request.data.get('use_semantic', True)
+            use_hybrid = _coerce_bool(request.data.get('use_hybrid', True))
+            use_semantic = _coerce_bool(request.data.get('use_semantic', True))
 
             # Get Azure RAG engine
             rag_engine = get_azure_rag_engine(index_name=index_name)
@@ -266,8 +286,8 @@ class AzureConversationalQueryView(APIView):
             index_name = validated_data.get('index_name')
             k = validated_data.get('k', 5)
             include_sources = validated_data.get('include_sources', True)
-            use_hybrid = request.data.get('use_hybrid', True)
-            use_semantic = request.data.get('use_semantic', True)
+            use_hybrid = _coerce_bool(request.data.get('use_hybrid', True))
+            use_semantic = _coerce_bool(request.data.get('use_semantic', True))
 
             # Get conversational Azure RAG engine
             rag_engine = cast(


### PR DESCRIPTION
## Summary

Backports two hardening fixes that already landed on the classic `views.py` path (PR #124 / #123) but were missed on the Azure pipeline in `rag_app/azure_views.py`.

## Changes

- **Boolean flag coercion (parity with `views.py`):** `AzureQueryView` and `AzureConversationalQueryView` read `use_hybrid` and `use_semantic` straight off `request.data`, bypassing `QueryRequestSerializer`'s `BooleanField` coercion. A client sending the JSON string `"false"` was treated as truthy (non-empty string). Both reads are now wrapped with a `_coerce_bool` helper replicating the one in `views.py` (defined locally to avoid coupling the Azure module to `src.rag_engine`).
- **Temp file leak on upload error (parity with `DocumentUploadView`):** `AzureDocumentUploadView.post` only deleted the temp upload on the success path, so a raise from `rag_engine.add_document(...)` leaked the file. The `default_storage.delete(file_path)` now runs in a `finally` block (guarded by `default_storage.exists`), mirroring the classic view's `try/finally` structure.

## Testing

- `python -m py_compile rag_app/azure_views.py` passes.
- Django is not installed in this environment, so `manage.py test` could not be run; verified via py_compile plus a careful manual review of the diff. Changes are confined to `azure_views.py` and mirror the already-reviewed classic-path patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193FofFePJp2CBnHfwMwXv9

---
_Generated by [Claude Code](https://claude.ai/code/session_0193FofFePJp2CBnHfwMwXv9)_