### PR TITLE
fix(docker): default DEBUG to False in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,10 @@ services:
       - PINECONE_ENVIRONMENT=${PINECONE_ENVIRONMENT}
       - VECTOR_DB_TYPE=faiss
       - DJANGO_SETTINGS_MODULE=django_app.settings
-      - DEBUG=True
+      # Default to production-safe DEBUG=False; opt into debug locally with
+      # `DEBUG=True docker compose up`. Hardcoding True here would leak stack
+      # traces and disable settings.py's security hardening for every deploy.
+      - DEBUG=${DEBUG:-False}
     volumes:
       - ./documents:/app/documents
       - ./indexes:/app/indexes


### PR DESCRIPTION
## What

`docker-compose.yml` hardcoded `DEBUG=True`. Since this is the documented run
path (and the only compose artifact — there's no separate prod compose),
anyone doing `docker compose up` started Django in debug mode:

- error pages leak stack traces, settings, and SQL queries, and
- `settings.py` skips its entire `if not DEBUG:` block — SSL redirect, HSTS,
  and secure/CSRF cookies are all disabled.

This silently overrode the production-safe `DEBUG=False` default that the rest
of the codebase is built around (`DEBUG = os.getenv('DEBUG', 'False').lower()
== 'true'`).

## Fix

Use `DEBUG=${DEBUG:-False}` so the container defaults to the safe value and
debug becomes opt-in per environment:

```
DEBUG=True docker compose up   # explicit local debugging
docker compose up              # DEBUG=False
```

## Testing

- `docker compose config` parses the file without error.
- Confirmed `settings.py:19` reads `DEBUG` from the env and treats the
  compose default `"False"` as boolean `False`, re-enabling the
  `if not DEBUG:` security block at `settings.py:199`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JHX5RDsKZP48Wrp9iex8J)_