### PR TITLE
fix(views): return 400 for malformed JSON in conversational query

### DIFF
--- a/rag_app/tests.py
+++ b/rag_app/tests.py
@@ -318,6 +318,33 @@ class APIViewsTest(TestCase):
                                   content_type='application/json')
         self.assertEqual(response.status_code, 404)
 
+    def test_query_malformed_json(self):
+        '''
+        Test query endpoint with a malformed JSON body.
+
+        Verifies a client-side JSON error yields 400, not 500.
+        '''
+        response = self.client.post('/api/query/',
+                                  '{"question": "unterminated',
+                                  content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        data = response.json()
+        self.assertIn('error', data)
+
+    def test_conversational_query_malformed_json(self):
+        '''
+        Test conversational query endpoint with a malformed JSON body.
+
+        Mirrors the /api/query/ handling so a broken JSON body returns 400
+        instead of falling through to a 500 internal error.
+        '''
+        response = self.client.post('/api/conversational-query/',
+                                  '{"question": "unterminated',
+                                  content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        data = response.json()
+        self.assertIn('error', data)
+
     def test_upload_document_api(self):
         '''
         Test document upload API endpoint.

--- a/rag_app/views.py
+++ b/rag_app/views.py
@@ -423,6 +423,10 @@ class ConversationalQueryView(APIView):
                     'error': 'An internal server error occurred during the conversational query.'
                 }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+        except json.JSONDecodeError:
+            return Response({
+                'error': 'Invalid JSON in request body'
+            }, status=status.HTTP_400_BAD_REQUEST)
         except (OSError, ValueError, RuntimeError):
             logger.error("Request processing failed", exc_info=True)
             return Response({


### PR DESCRIPTION
## Summary

`ConversationalQueryView.post` was missing the `except json.JSONDecodeError` handler that its sibling `QueryView.post` already has. Because both views wrap the request handling in a generic `except (OSError, ValueError, RuntimeError)` — and `json.JSONDecodeError` subclasses `ValueError` — a malformed JSON body sent to `/api/conversational-query/` fell through to the generic handler and returned a **500 Internal Server Error** instead of a **400 Bad Request**. It also logged the client-caused error at `ERROR` level, adding noise to `logs/django.log`.

This mirrors the existing `QueryView` handling so the two parallel endpoints behave consistently: a broken JSON body now returns `400 {"error": "Invalid JSON in request body"}`.

## Changes

- `rag_app/views.py`: add `except json.JSONDecodeError → 400` in `ConversationalQueryView.post`, placed before the generic handler (matching `QueryView`).
- `rag_app/tests.py`: add regression tests `test_query_malformed_json` and `test_conversational_query_malformed_json` asserting `400` for a malformed body on both endpoints.

## Testing

- `python manage.py test rag_app` → **18 tests pass** (default auth config).
- Verified the regression test fails (`500 != 400`) with the view change reverted, confirming it catches the bug.

---
_Generated by [Claude Code](https://claude.ai/code/session_014EZrecK8Ci9TchwVWppNQx)_