### PR TITLE
fix(views): return 400 for non-object JSON request bodies

### DIFF
--- a/rag_app/tests.py
+++ b/rag_app/tests.py
@@ -345,6 +345,35 @@ class APIViewsTest(TestCase):
         data = response.json()
         self.assertIn('error', data)
 
+    def test_query_non_object_json_body(self):
+        '''
+        Test query endpoint with a valid-JSON, non-object body.
+
+        A body such as a JSON array or string decodes cleanly but is not a
+        dict; it must return 400 rather than falling through to an uncaught
+        AttributeError (500) when the view reads ``.get('question')``.
+        '''
+        response = self.client.post('/api/query/',
+                                  json.dumps([1, 2, 3]),
+                                  content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        data = response.json()
+        self.assertIn('error', data)
+
+    def test_conversational_query_non_object_json_body(self):
+        '''
+        Test conversational query endpoint with a non-object JSON body.
+
+        Mirrors the /api/query/ handling so a non-dict JSON body returns 400
+        instead of falling through to a 500 internal error.
+        '''
+        response = self.client.post('/api/conversational-query/',
+                                  json.dumps("just a string"),
+                                  content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        data = response.json()
+        self.assertIn('error', data)
+
     def test_upload_document_api(self):
         '''
         Test document upload API endpoint.

--- a/rag_app/views.py
+++ b/rag_app/views.py
@@ -35,7 +35,18 @@ FILE_PROCESSING_ERROR_MESSAGE = 'An internal error occurred while processing thi
 def _parse_request_data(request):
     """Read JSON or form-encoded payloads into a plain dictionary."""
     if request.body:
-        return json.loads(request.body)
+        data = json.loads(request.body)
+        # A syntactically valid but non-object body (list, string, number)
+        # would otherwise reach ``data.get(...)`` in the callers and raise an
+        # uncaught AttributeError (HTTP 500). Reject it as a malformed request
+        # so it lands on the existing JSONDecodeError -> 400 handler instead.
+        if not isinstance(data, dict):
+            raise json.JSONDecodeError(
+                'Request body must be a JSON object',
+                request.body.decode('utf-8', 'replace'),
+                0,
+            )
+        return data
     return request.POST.dict()
 
 


### PR DESCRIPTION
## Summary

`_parse_request_data` returned whatever `json.loads(request.body)` decoded and handed it straight to the callers. A syntactically valid but **non-object** body — a JSON array, string, or number (e.g. `[1,2,3]`, `"hi"`, `5`) — decodes cleanly, so `QueryView.post` / `ConversationalQueryView.post` then call `data.get('question', '')` on a `list`/`str`/`int` and raise an **uncaught `AttributeError`**. The outer handlers only catch `json.JSONDecodeError` and `(OSError, ValueError, RuntimeError)`, so this surfaced as an HTTP **500** on a plain client mistake.

## Change

- In `_parse_request_data`, reject non-`dict` decoded bodies by raising `json.JSONDecodeError`, so they land on the existing `JSONDecodeError → 400` handler that both endpoints already have. Malformed JSON continues to behave exactly as before.
- Added `test_query_non_object_json_body` and `test_conversational_query_non_object_json_body` mirroring the existing `test_query_malformed_json` tests.

## Verification

- Parsing logic verified in isolation: `dict` bodies pass through unchanged; `[1,2,3]`, `"hi"`, `5`, `true`, and malformed JSON all raise `JSONDecodeError` (→ 400).
- `python -m ast` parse check passes on both `views.py` and `tests.py`.

_The full Django test run needs the RAG dependencies (langchain/faiss) that aren't installable in this environment, so the two new tests are validated logically rather than executed here — CI will run them._

---
_Generated by [Claude Code](https://claude.ai/code/session_016JeXARZo3JvULrjBzujdzV)_