### PR TITLE
fix(conversation): scope conversational RAG history per session

### DIFF
--- a/rag_app/tests.py
+++ b/rag_app/tests.py
@@ -431,7 +431,7 @@ class WebViewsTest(TestCase):
     def test_home_view(self):
         '''
         Test the home page loads.
-        
+
         Verifies home page returns 200 status and contains
         expected page title.
         '''
@@ -440,3 +440,71 @@ class WebViewsTest(TestCase):
         self.assertContains(response, 'RAG Document Q&A System')
         self.assertContains(response, 'Upload Documents')
         self.assertContains(response, 'Ask Questions')
+
+
+class ConversationalRAGCacheTest(TestCase):
+    '''
+    Test session-scoped caching of conversational RAG engines.
+
+    Verifies that conversation history is isolated per browser session
+    rather than shared process-wide per index, and that the cache is
+    bounded by an LRU eviction cap.
+    '''
+
+    def setUp(self):
+        '''
+        Set up test fixtures.
+
+        Swaps ConversationalRAG for a lightweight stub so the cache logic
+        can be exercised without the heavy RAG/LLM dependencies, and starts
+        from an empty cache.
+        '''
+        from rag_app import views
+
+        self.views = views
+        self._real_engine = views.ConversationalRAG
+
+        class _StubEngine:
+            def __init__(self, index_name="default"):
+                self.index_name = index_name
+
+        views.ConversationalRAG = _StubEngine
+        views._conversational_rags.clear()
+
+    def tearDown(self):
+        '''Restore the real engine and empty the cache after each test.'''
+        self.views.ConversationalRAG = self._real_engine
+        self.views._conversational_rags.clear()
+
+    def test_sessions_get_isolated_engines(self):
+        '''
+        Two sessions querying the same index get distinct engines.
+
+        Keying by (session_key, index_name) prevents one user's conversation
+        history from leaking into another's, while a repeated (session, index)
+        lookup returns the cached instance.
+        '''
+        engine_a = self.views.get_conversational_rag('shared_index', 'session-a')
+        engine_b = self.views.get_conversational_rag('shared_index', 'session-b')
+        self.assertIsNot(engine_a, engine_b)
+        self.assertIs(
+            engine_a,
+            self.views.get_conversational_rag('shared_index', 'session-a'),
+        )
+
+    def test_cache_is_bounded_by_lru_cap(self):
+        '''
+        The cache never exceeds the configured maximum size.
+
+        Creating more engines than the cap evicts the least-recently-used
+        entries while keeping the most recent.
+        '''
+        cap = self.views._MAX_CONVERSATIONAL_RAGS
+        for i in range(cap + 5):
+            self.views.get_conversational_rag('idx', f'session-{i}')
+        self.assertLessEqual(len(self.views._conversational_rags), cap)
+        self.assertNotIn(('session-0', 'idx'), self.views._conversational_rags)
+        self.assertIn(
+            (f'session-{cap + 4}', 'idx'),
+            self.views._conversational_rags,
+        )

--- a/rag_app/views.py
+++ b/rag_app/views.py
@@ -8,6 +8,7 @@ import json
 import os
 import time
 import logging
+from collections import OrderedDict
 
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
@@ -26,7 +27,13 @@ from .models import Document, DocumentIndex, Query, QuerySession
 
 # Global RAG engine instances (similar to FastAPI implementation)
 _rag_engines = {}
-_conversational_rags = {}
+# Conversational engines are keyed by ``(session_key, index_name)`` so each
+# browser session keeps its own conversation history. Keying by index alone
+# let every session that queried the same index share one process-global
+# history, leaking prior turns between users. Bounded with an LRU cap so the
+# cache cannot grow without limit as sessions accumulate over the process life.
+_conversational_rags = OrderedDict()
+_MAX_CONVERSATIONAL_RAGS = 128
 logger = logging.getLogger(__name__)
 
 FILE_PROCESSING_ERROR_MESSAGE = 'An internal error occurred while processing this file.'
@@ -86,17 +93,31 @@ def get_rag_engine(index_name: str = "default"):
     return _rag_engines[index_name]
 
 
-def get_conversational_rag(index_name: str = "default"):
+def get_conversational_rag(index_name: str = "default", session_key: str = None):
     '''
-    Get or create conversational RAG engine instance for given index.
-    
+    Get or create conversational RAG engine instance for a session and index.
+
+    Keying by ``session_key`` keeps each user's conversation history isolated
+    instead of sharing one process-global history per index. A missing
+    ``session_key`` falls back to a shared key so non-session callers keep
+    working.
+
     :param index_name: Name of the document index
-    :return: ConversationalRAG instance for the specified index
+    :param session_key: Session identifier isolating conversation history
+    :return: ConversationalRAG instance for the specified session and index
     '''
-    if index_name not in _conversational_rags:
-        _conversational_rags[index_name] = ConversationalRAG(
+    cache_key = (session_key, index_name)
+    if cache_key not in _conversational_rags:
+        # Evict the least-recently-used engine once the cap is reached so the
+        # cache cannot grow without bound as sessions accumulate.
+        while len(_conversational_rags) >= _MAX_CONVERSATIONAL_RAGS:
+            _conversational_rags.popitem(last=False)
+        _conversational_rags[cache_key] = ConversationalRAG(
             index_name=index_name)
-    return _conversational_rags[index_name]
+    else:
+        # Mark as most-recently-used for the LRU eviction order.
+        _conversational_rags.move_to_end(cache_key)
+    return _conversational_rags[cache_key]
 
 
 class IndexView(TemplateView):
@@ -403,7 +424,7 @@ class ConversationalQueryView(APIView):
 
             # Perform conversational query
             start_time = time.time()
-            conversational_rag = get_conversational_rag(index_name)
+            conversational_rag = get_conversational_rag(index_name, session_key)
 
             try:
                 result = conversational_rag.conversational_query(question)
@@ -560,8 +581,10 @@ def clear_documents(request):
         # Clear RAG engine cache
         if index_name in _rag_engines:
             del _rag_engines[index_name]
-        if index_name in _conversational_rags:
-            del _conversational_rags[index_name]
+        # Conversational engines are keyed by (session_key, index_name); drop
+        # every session's engine for this index, not just a single entry.
+        for cache_key in [k for k in _conversational_rags if k[1] == index_name]:
+            del _conversational_rags[cache_key]
 
         # Delete all documents from database
         Document.objects.filter(index=index).delete()

--- a/rag_app/views.py
+++ b/rag_app/views.py
@@ -9,6 +9,7 @@ import os
 import time
 import logging
 from collections import OrderedDict
+from typing import Optional
 
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
@@ -93,7 +94,7 @@ def get_rag_engine(index_name: str = "default"):
     return _rag_engines[index_name]
 
 
-def get_conversational_rag(index_name: str = "default", session_key: str = None):
+def get_conversational_rag(index_name: str = "default", session_key: Optional[str] = None):
     '''
     Get or create conversational RAG engine instance for a session and index.
 


### PR DESCRIPTION
## Problem

`_conversational_rags` cached `ConversationalRAG` engines in a process-global dict keyed by **index name alone**:

```python
def get_conversational_rag(index_name="default"):
    if index_name not in _conversational_rags:
        _conversational_rags[index_name] = ConversationalRAG(index_name=index_name)
    return _conversational_rags[index_name]
```

So every browser session that queried the same index shared **one** engine and its `conversation_history`. One user's prior turns could leak into another user's context — the cross-session concern flagged on #176 and tracked by #177.

## Fix

- **Key the cache by `(session_key, index_name)`** so each session keeps its own conversation history. `get_conversational_rag` now takes an optional `session_key` (falls back to a shared key for non-session callers).
- **Pass the request session key through** from `ConversationalQueryView` (it already resolves `session_key` for the DB record).
- **`clear_documents` drops every session's engine for the cleared index**, not a single entry, now that keys are tuples.
- **Bound the cache with a simple LRU eviction cap** (`OrderedDict` + `_MAX_CONVERSATIONAL_RAGS = 128`) so it can't grow without limit as sessions accumulate — addressing the eviction concern raised in #177.

## Scope / relationship to #176

Deliberately **does not touch `clear_conversation`** (the two lines PR #176 changes), so this branch does not conflict with #176. Fully scoping the *in-memory clear* to the requesting session pairs naturally with #176's method-name fix and can land alongside it; this PR covers the isolation keying + eviction cap, which is the core of #177.

## Tests

Added `ConversationalRAGCacheTest` (stubs `ConversationalRAG`, so no heavy RAG deps needed):
- `test_sessions_get_isolated_engines` — two sessions on the same index get distinct engines; a repeat lookup returns the cached instance.
- `test_cache_is_bounded_by_lru_cap` — the cache never exceeds the cap and evicts least-recently-used entries.

`python -m py_compile` passes on both changed files.

Refs #177

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGGsEYpFpv8miMzZSUV4s4)_